### PR TITLE
GE4-19130 Add kubernetes probes

### DIFF
--- a/service.json
+++ b/service.json
@@ -78,6 +78,42 @@
           "restart_policy": {
             "condition": "on-failure",
             "delay": "30s"
+          },
+          "livenessProbe": {
+            "httpGet": {
+              "path": "/metrics",
+              "port": 7071,
+              "scheme": "HTTP"
+            },
+            "initialDelaySeconds": 30,
+            "periodSeconds": 10,
+            "timeoutSeconds": 5,
+            "successThreshold": 1,
+            "failureThreshold": 3
+          },
+          "readinessProbe": {
+            "httpGet": {
+              "path": "/metrics",
+              "port": 7071,
+              "scheme": "HTTP"
+            },
+            "initialDelaySeconds": 30,
+            "periodSeconds": 10,
+            "timeoutSeconds": 5,
+            "successThreshold": 1,
+            "failureThreshold": 3
+          },
+          "startupProbe": {
+            "httpGet": {
+              "path": "/metrics",
+              "port": 7071,
+              "scheme": "HTTP"
+            },
+            "initialDelaySeconds": 30,
+            "periodSeconds": 10,
+            "timeoutSeconds": 5,
+            "successThreshold": 1,
+            "failureThreshold": 3
           }
         }
       },


### PR DESCRIPTION
Best way to run zookeeker healthcheck would probably involve running script executing [ruok command](https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html#sc_zkCommands)

However:
- service.json format does not support `exec` probes
- also we have no netcat installed during runtime(not a big deal, can easily add it)

Therefore this implementation is essentially a workaround until exec probes are supported in service.json.