### PR TITLE
GE4-25502: Vector logging compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.7.0
+FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.12.2
 
 ARG zookeper_version=3.8.5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN curl https://downloads.apache.org/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/a
 #Configure
 RUN mv /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg
 
-ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSION}-openjdk-amd64
-ENV ZK_HOME /opt/zookeeper
+ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk-amd64
+ENV ZK_HOME=/opt/zookeeper
 RUN sed  -i "s|/tmp/zookeeper|$ZK_HOME/data|g" $ZK_HOME/conf/zoo.cfg; mkdir $ZK_HOME/data
 
 RUN mkdir -p /opt/prometheus/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.7.0
 
-ARG zookeper_version=3.8.4
+ARG zookeper_version=3.8.5
 
 ENV ZOOKEEPER_VERSION=$zookeper_version
 ENV PORT=2181

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -59,7 +59,7 @@
       <totalSizeCap>30MB</totalSizeCap>
     </rollingPolicy>
     <encoder>
-        <pattern>{ "@timestamp":"%date", "level":"%level", "thread":"[%thread]", "logger":"%logger{10}", "file":"[%file:%line]", "message":"%msg" }</pattern>
+        <pattern>{ "@timestamp":"%date", "level":"%level", "thread":"[%thread]", "logger":"%logger{10}", "file":"[%file:%line]", "message":"%msg" }%n</pattern>
     </encoder>
     <append>true</append>
 </appender>


### PR DESCRIPTION
- Updated the base image to 4.12.2
- Fixed logs malformation by adding a missing newline to the log pattern
- Updated Zookeeper version from 3.8.4 to 3.8.5, fixing build failures caused by 404 errors
- Changed ENV assignments in `Dockerfile` to use `=` (fixes LegacyKeyValueFormat warning)
