### PR TITLE
GE4-29345: fix(security): bump ge-ubuntu-generic 4.18.0->4.24.0 (CVE-2026-27143, CVSS 9.8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.18.0
+FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.24.0
 
 ARG zookeper_version=3.8.6
 


### PR DESCRIPTION
## CVE-2026-27143 — Go compiler memory corruption (CVSS 9.8 CRITICAL)

**Jira**: https://jira.germanedge.com/browse/GE4-29345
**CVE**: CVE-2026-27143 | **CVSS**: 9.8 CRITICAL | **SLA**: 2026-04-10 (overdue)

### Change

`ge-ubuntu-generic:4.18.0` -> `ge-ubuntu-generic:4.24.0`

`ge-ubuntu-generic:4.24.0` includes:
- `go-exporter:0.8.0` built from `golang:1.25.9` - fixes `/usr/bin/go-exporter` binary
- `consul:1.22.6` (up from 1.21.4) - fixes CVE-2025-68121

### Remaining (follow-up PR pending upstream releases)
- consul 1.22.6 compiled with Go 1.25.8 - awaiting consul 1.22.7+ from HashiCorp
- filebeat 8.19.14 compiled with Go 1.25.8 - awaiting 8.19.15+ from Elastic

### Breaking changes
None. Patch-level base image bump.
