### PR TITLE
fix(security): bump ge-ubuntu-generic to 4.24.0 (GE4-28968 / CVE-2025-68121)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.18.0
+FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.24.0
 
 ARG zookeper_version=3.8.6
 


### PR DESCRIPTION
## Summary

Fixes **CVE-2025-68121** (CVSS 10.0 CRITICAL) — TLS resumed handshake bypass in Go stdlib (`crypto/tls`).

**Jira**: [GE4-28968](https://jira.germanedge.com/browse/GE4-28968)

**Change**: `ge-ubuntu-generic:4.18.0` → `ge-ubuntu-generic:4.24.0`

`4.24.0` includes consul 1.22.6 (built with Go 1.25.8), which contains the patched `crypto/tls` package that closes CVE-2025-68121.

https://nvd.nist.gov/vuln/detail/CVE-2025-68121

## Impact Attestation

| Field | Value |
|---|---|
| **Fix component** | consul 1.22.6 / Go 1.25.8 in `ge-ubuntu-generic:4.24.0` |
| **Behavioral change** | Runtime refresh of `ge-ubuntu-generic` base image |
| **Breaking changes** | None — version bump only |

## Validation
- [ ] CI passes on this PR
- [ ] Re-scan confirms CVE-2025-68121 no longer reported

_Opened automatically by `edgeone.cve-triage-patrol` — GE4-28968 cascade wave._