### PR TITLE
GE4-33765: fix(security): bump ge-ubuntu-generic 4.24.0->4.25.0 (CVE-2026-34986)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.24.0
+FROM germanedge-docker.artifactory.new-solutions.com/edge-one/ge-ubuntu-generic:4.25.0
 
 ARG zookeper_version=3.8.6
 


### PR DESCRIPTION
## Summary

Bump `ge-ubuntu-generic` from `4.24.0` to `4.25.0` to remediate CVE-2026-34986.

**CVE**: [CVE-2026-34986](https://nvd.nist.gov/vuln/detail/CVE-2026-34986)
**CVSS**: 7.5 (High)
**Component**: filebeat (go-jose/v4 v4.1.3 → v4.1.4 via filebeat 8.19.14 → 8.19.15)
**Jira**: [GE4-33765](https://jira.germanedge.com/browse/GE4-33765)

Part of the base image cascade for `ge-ubuntu-generic` CVE fix. Layer 1 consumer PR.

## Changes

- `Dockerfile`: update `FROM .../ge-ubuntu-generic:4.24.0` → `:4.25.0`

## Traceability

Jira: GE4-33765
Root fix: https://github.com/Germanedge/ge-ubuntu-generic/pull/134 (merged 2026-05-16)

[+semver: minor]
