### PR TITLE
GE4-47437: Define external app metadata in service.json [+semver: skip]

### DIFF
--- a/service.json
+++ b/service.json
@@ -4,6 +4,10 @@
   "servicetype": "core",
   "ge_domain": "platform",
   "description": "zookeeper",
+  "metadata": {
+    "build_source": "zookeeper",
+    "build_source_version": "3.8.6"
+  },
   "homepage": "https://github.com/germanedge/zookeeper-docker",
   "keywords": [
     "kafka",


### PR DESCRIPTION
Adds a `metadata` block to `service.json` recording the wrapped application's build source and installed version, taken from the Dockerfile's `EXTERNAL_APP_NAME` / `EXTERNAL_APP_VERSION`. The stack-creator datamodel uses these to derive the `{version}+{build_source}.{build_source_version}` version alias and adds them to the manifest as `build_source` and `build_source_version` labels, which Germanedge/platform-administration#214 pulls to enrich the metadata.
